### PR TITLE
Fix grab a ticket link

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -36,7 +36,7 @@
             background-image: url('https://2016.belgrade.wordcamp.org/files/2016/03/ticket-icon.png');
             background-size: 100%;
             left: 18px;
-            top: 16px;
+            top: 13px;
         }
     }
 }

--- a/style.scss
+++ b/style.scss
@@ -7,6 +7,7 @@
     bottom: 20px;
     right: 40px;
     padding: 0 !important;
+    z-index: 1;
 
     a {
         font-size: 1rem;


### PR DESCRIPTION
Currently the grab a ticket link is getting under the facebook widget. Also the icon should be a few pixels higher.
